### PR TITLE
Add links to URL for running execution

### DIFF
--- a/lib/lita/handlers/rundeck.rb
+++ b/lib/lita/handlers/rundeck.rb
@@ -268,7 +268,8 @@ module Lita
               "run.still_running",
               id: execution.id,
               current_duration: current_duration,
-              average_duration: average_duration
+              average_duration: average_duration,
+              job_url: execution.href,
               )
             sleep 10
           else
@@ -281,7 +282,7 @@ module Lita
       def resolve(e)
         case e.status
         when "running"
-          t("run.success", id: e.id, average_duration: e.job.average_duration.to_f / 1000.0)
+          t("run.success", id: e.id, average_duration: e.job.average_duration.to_f / 1000.0, job_url: e.href)
         when "api.error.execution.conflict"
           t("run.conflict")
         when "api.error.item.unauthorized"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -38,8 +38,8 @@ en:
           token_unauthorized: "API token is unauthorized or lacks runAs permission; check the apitoken.aclpolicy"
           unauthorized: "You aren't authorized to run jobs"
           failed: "Something went wrong with the job execution"
-          success: "Execution %{id} is running. Average job duration is %{average_duration} seconds."
-          still_running: "Execution %{id} has been running for %{current_duration}s (%{average_duration}s average)"
+          success: "Execution %{id} is running. Average job duration is %{average_duration} seconds. Details at %{job_url}"
+          still_running: "Execution %{id} has been running for %{current_duration}s (%{average_duration}s average). Details at %{job_url}"
           conflict: "Job is already running and only allows one execution at a time"
         alias:
           none: "No aliases have been registered yet"


### PR DESCRIPTION
This PR adds a URL for use within Lita to quickly bring context into the ChatRoom when commands are executed.

